### PR TITLE
fix module name in test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /.merlin
 /_build/
-/creal.install
+/*.install

--- a/test.ml
+++ b/test.ml
@@ -2,8 +2,8 @@
 (*s Test program for [Creal]. *)
 
 open Printf
-open Creal
-open Creal.Infixes
+open CReal
+open CReal.Infixes
 
 (*s Options *)
 


### PR DESCRIPTION
Hi,

In the test file, the creal module was spelled `Creal` wheras it should have been `CReal`. I guess the name has been changed without testing. It works fine now.

(I also updated the .gitignore to ignore missing dune generated files)

Cheers.